### PR TITLE
Move informative messages to stderr so they don't interfere with JSON

### DIFF
--- a/lib/barnowl.js
+++ b/lib/barnowl.js
@@ -30,7 +30,7 @@ function BarnOwl(n, requiresMixing) {
     self.emit('sensorData', sensorData);
   });
 
-  console.log("reelyActive BarnOwl instance is listening for an open IoT");
+  console.warn("reelyActive BarnOwl instance is listening for an open IoT");
   events.EventEmitter.call(this);
 };
 util.inherits(BarnOwl, events.EventEmitter);

--- a/lib/core/listenerservice/udplistener.js
+++ b/lib/core/listenerservice/udplistener.js
@@ -33,7 +33,7 @@ function UdpListener(path) {
 
   server.on('listening', function () {
     var address = server.address();
-    console.log('UDP Listening on ' + address.address + ':' + address.port);
+    console.warn('UDP Listening on ' + address.address + ':' + address.port);
   });
   server.on('message', function (data, remote) {
     var origin = remote.address + ':' + remote.port;


### PR DESCRIPTION
output.

Not sure if this is something that's useful for others, but when I was reading from the json string while dumping to console, it was useful to have messages that weren't part of the json payload seperated out onto standard error instead of standard output.  This way, you can pipe barnyards output to another program that can read a JSON stream.   
