### PR TITLE
Make an option for minRSSI

### DIFF
--- a/lib/barnowl.js
+++ b/lib/barnowl.js
@@ -24,7 +24,12 @@ function BarnOwl(options) {
   self.processorServiceInstance.bind(this.hardwareInterfaceInstance);
 
   self.processorServiceInstance.on('visibilityEvent', function(tiraid) {
-    self.emit('visibilityEvent', tiraid);
+    var rssi = tiraid.radioDecodings[0].rssi;
+    if(rssi > options.minRSSI) {
+      self.emit('visibilityEvent', tiraid);
+    }else {
+      console.log(`rssi ${rssi} < ${options.minRSSI}`)
+    }
   });
 
   self.processorServiceInstance.on('reelEvent', function(data) {


### PR DESCRIPTION
Currently barnowl does not have a option to only send event with `rssi > someNumber`. This PR add a feature for that.